### PR TITLE
Container move

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,21 @@ function generateCommands(origin, dest) {
   var destCmds    = _.chain(dest.topology.containers)
                      .values()
                      .map(function(container) {
-                       return {
-                           cmd: 'configure'
-                         , id: container.id
+                       var origConts = origin.topology.containers
+
+                       if (origConts[container.id] && origConts[container.id].containedBy != container.containedBy) {
+                         return [{
+                             cmd: 'detach'
+                           , id: container.id
+                         }, {
+                             cmd: 'configure'
+                           , id: container.id
+                         }]
+                       } else {
+                         return {
+                             cmd: 'configure'
+                           , id: container.id
+                         }
                        }
                      })
                      .value()

--- a/test/dirty.js
+++ b/test/dirty.js
@@ -154,4 +154,59 @@ describe("dirty sheet planning", function() {
      , id: machine4.id
    }])
   })
+
+  it("should create a plan that moves a machine from an host to another", function() {
+
+    var machine1Orig = defineMachine(amiDefinition)
+
+      , machine1Dest = _.cloneDeep(machine1Orig)
+
+      , machine2Orig = defineMachine(amiDefinition)
+
+      , machine2Dest = _.cloneDeep(machine2Orig)
+
+      , machine3Orig = defineMachine(dockDef, machine1Orig)
+
+      , machine3Dest = _.cloneDeep(machine3Orig)
+
+      , dest = buildSheet("start and stop")
+
+      , plan
+
+      , origin = buildSheet("dirty sheet")
+
+   origin.topology.containers[machine1Orig.id] = machine1Orig
+   origin.topology.containers[machine2Orig.id] = machine2Orig
+   origin.topology.containers[machine3Orig.id] = machine3Orig
+
+   machine3Dest.containedBy = machine2Dest.id
+   machine2Dest.contains.push(machine3Dest.id)
+   machine1Dest.contains = []
+
+   dest.topology.containers[machine1Dest.id] = machine1Dest
+   dest.topology.containers[machine2Dest.id] = machine2Dest
+   dest.topology.containers[machine3Dest.id] = machine3Dest
+
+   plan = planner(origin, dest)
+
+   expect(plan).to.eql([{
+       cmd: "unlink"
+     , id: machine3Orig.id
+   }, {
+       cmd: "stop"
+     , id: machine3Orig.id
+   }, {
+       cmd: "remove"
+     , id: machine3Orig.id
+   }, {
+       cmd: "add"
+     , id: machine3Orig.id
+   }, {
+       cmd: "start"
+     , id: machine3Orig.id
+   }, {
+       cmd: "link"
+     , id: machine3Orig.id
+   }])
+  })
 })


### PR DESCRIPTION
Currently the planner does not detect the scenario where a container is moved. For example if a docker container is moved in the topology from instance to another, without being rebuild - i.e. it retains the same id, then the planner will report that there is no action required.
